### PR TITLE
Fallback env-keys, Expand env-vars, Slice and Maps support, Default value

### DIFF
--- a/env.go
+++ b/env.go
@@ -85,6 +85,7 @@ func Unmarshal(es EnvSet, v interface{}) error {
 			return ErrUnexportedField
 		}
 
+		found := false
 		for _, tag := range tagValues {
 			envVar, ok := es[tag]
 			if !ok {
@@ -96,7 +97,18 @@ func Unmarshal(es EnvSet, v interface{}) error {
 				return err
 			}
 			delete(es, tag)
+			found = true
 			break
+		}
+		if !found {
+			defaultValue := typeField.Tag.Get("default")
+			if defaultValue == "" {
+				continue
+			}
+			err := set(es, typeField.Type, valueField, defaultValue)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/env_test.go
+++ b/env_test.go
@@ -327,6 +327,19 @@ func TestMarshalPointer(t *testing.T) {
 	empty := ""
 	validStruct := ValidStruct{
 		PointerString: &empty,
+		SliceTest:     []string{"A", "B", "C"},
+		SliceNumber:   []int{1, 2, 3},
+		SliceBool:     []bool{true, false, true},
+		MapString: map[string]string{
+			"k1": "v1",
+			"k2": "v2",
+			"k3": "v3",
+		},
+		MapIFace: map[string]interface{}{
+			"k1": 1,
+			"k2": 2,
+			"k3": 3,
+		},
 	}
 	es, err := Marshal(&validStruct)
 	if err != nil {

--- a/env_test.go
+++ b/env_test.go
@@ -21,7 +21,7 @@ import (
 
 type ValidStruct struct {
 	// Home should match Environ because it has a "env" field tag.
-	Home string `env:"HOME"`
+	Home string `env:"HOME" default:"myHome"`
 
 	PExpand string `env:"PEXPAND"`
 
@@ -57,8 +57,10 @@ type ValidStruct struct {
 	// Slice of bools
 	SliceBool []bool `env:"SLICEBOOL"`
 
+	// String map
 	MapString map[string]string `env:"MAPSTRING"`
 
+	// String interface map
 	MapIFace map[string]interface{} `env:"MAPIFACE"`
 
 	// Additional supported types
@@ -124,6 +126,26 @@ func TestUnmarshal(t *testing.T) {
 		t.Errorf("Expected field value to be '%s' but got '%s'", "/var/bin:/home/test", validStruct.PExpand)
 	}
 
+	if len(validStruct.SliceTest) != 3 {
+		t.Errorf("Expected field length to be '%d' but got '%d'", 3, len(validStruct.SliceTest))
+	}
+
+	if len(validStruct.SliceNumber) != 3 {
+		t.Errorf("Expected field length to be '%d' but got '%d'", 3, len(validStruct.SliceNumber))
+	}
+
+	if len(validStruct.SliceBool) != 3 {
+		t.Errorf("Expected field length to be '%d' but got '%d'", 3, len(validStruct.SliceBool))
+	}
+
+	if len(validStruct.MapString) != 3 {
+		t.Errorf("Expected field length to be '%d' but got '%d'", 3, len(validStruct.MapString))
+	}
+
+	if len(validStruct.MapIFace) != 3 {
+		t.Errorf("Expected field length to be '%d' but got '%d'", 3, len(validStruct.MapIFace))
+	}
+
 	v, ok := environ["HOME"]
 	if ok {
 		t.Errorf("Expected field '%s' to not exist but got '%s'", "HOME", v)
@@ -148,6 +170,10 @@ func TestUnmarshalPointer(t *testing.T) {
 	err := Unmarshal(environ, &validStruct)
 	if err != nil {
 		t.Errorf("Expected no error but got '%s'", err)
+	}
+
+	if validStruct.Home != "myHome" {
+		t.Errorf("Expected field value to be '%s' but got '%s'", "myHome", validStruct.Home)
 	}
 
 	if validStruct.PointerString == nil {

--- a/env_test.go
+++ b/env_test.go
@@ -23,6 +23,8 @@ type ValidStruct struct {
 	// Home should match Environ because it has a "env" field tag.
 	Home string `env:"HOME"`
 
+	PExpand string `env:"PEXPAND"`
+
 	// Jenkins should be recursed into.
 	Jenkins struct {
 		Workspace string `env:"WORKSPACE"`
@@ -32,7 +34,7 @@ type ValidStruct struct {
 	}
 
 	// PointerString should be nil if unset, with "" being a valid value.
-	PointerString *string `env:"POINTER_STRING"`
+	PointerString *string `env:"POINTER_STRING, POINTER_STRING2"`
 
 	// PointerInt should work along with other supported types.
 	PointerInt *int `env:"POINTER_INT"`
@@ -66,6 +68,8 @@ func TestUnmarshal(t *testing.T) {
 		"EXTRA":     "extra",
 		"INT":       "1",
 		"BOOL":      "true",
+		"PEXPAND":   "$PATH:/home/test",
+		"PATH":      "/var/bin",
 	}
 
 	var validStruct ValidStruct
@@ -98,6 +102,10 @@ func TestUnmarshal(t *testing.T) {
 		t.Errorf("Expected field value to be '%t' but got '%t'", true, validStruct.Bool)
 	}
 
+	if validStruct.PExpand != "/var/bin:/home/test" {
+		t.Errorf("Expected field value to be '%s' but got '%s'", "/var/bin:/home/test", validStruct.PExpand)
+	}
+
 	v, ok := environ["HOME"]
 	if ok {
 		t.Errorf("Expected field '%s' to not exist but got '%s'", "HOME", v)
@@ -113,7 +121,7 @@ func TestUnmarshal(t *testing.T) {
 
 func TestUnmarshalPointer(t *testing.T) {
 	environ := map[string]string{
-		"POINTER_STRING":         "",
+		"POINTER_STRING2":        "",
 		"POINTER_INT":            "1",
 		"POINTER_POINTER_STRING": "",
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -48,6 +48,19 @@ type ValidStruct struct {
 	// Extra should remain with a zero-value because it has no "env" field tag.
 	Extra string
 
+	// Slice of strings
+	SliceTest []string `env:"SLICE"`
+
+	// Slice of ints
+	SliceNumber []int `env:"SLICENUMBER"`
+
+	// Slice of bools
+	SliceBool []bool `env:"SLICEBOOL"`
+
+	MapString map[string]string `env:"MAPSTRING"`
+
+	MapIFace map[string]interface{} `env:"MAPIFACE"`
+
 	// Additional supported types
 	Int  int  `env:"INT"`
 	Bool bool `env:"BOOL"`
@@ -63,13 +76,18 @@ type UnexportedStruct struct {
 
 func TestUnmarshal(t *testing.T) {
 	environ := map[string]string{
-		"HOME":      "/home/test",
-		"WORKSPACE": "/mnt/builds/slave/workspace/test",
-		"EXTRA":     "extra",
-		"INT":       "1",
-		"BOOL":      "true",
-		"PEXPAND":   "$PATH:/home/test",
-		"PATH":      "/var/bin",
+		"HOME":        "/home/test",
+		"WORKSPACE":   "/mnt/builds/slave/workspace/test",
+		"EXTRA":       "extra",
+		"INT":         "1",
+		"BOOL":        "true",
+		"PEXPAND":     "$PATH:/home/test",
+		"PATH":        "/var/bin",
+		"SLICE":       "A, B, C",
+		"SLICENUMBER": "1,2,3",
+		"SLICEBOOL":   "true, false, true",
+		"MAPSTRING":   "k1=$PATH, k2=v2, k3=v3",
+		"MAPIFACE":    "k1=v1, k2=v2, k3=$PATH",
 	}
 
 	var validStruct ValidStruct


### PR DESCRIPTION
This `PR` adds the following enhancements:

- Fallback to other environment variables keys in case not found. (useful for backward compatibility of env-vars)
- Expand env vars when a value has `${var}` or `$var`
- Support to marshall and unmarshall Slice and Maps
- Support to default values if no environment variable was found.